### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/Tests/DefaultRendererTest.php
+++ b/Tests/DefaultRendererTest.php
@@ -7,9 +7,9 @@
 
 namespace Joomla\Profiler\Tests;
 
-use Joomla\Profiler\Renderer\DefaultRenderer;
 use Joomla\Profiler\ProfilePoint;
 use Joomla\Profiler\Profiler;
+use Joomla\Profiler\Renderer\DefaultRenderer;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/Tests/ProfilerTest.php
+++ b/Tests/ProfilerTest.php
@@ -7,10 +7,10 @@
 
 namespace Joomla\Profiler\Tests;
 
-use Joomla\Profiler\ProfilerRendererInterface;
-use Joomla\Profiler\Renderer\DefaultRenderer;
 use Joomla\Profiler\ProfilePoint;
 use Joomla\Profiler\Profiler;
+use Joomla\Profiler\ProfilerRendererInterface;
+use Joomla\Profiler\Renderer\DefaultRenderer;
 use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
 

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -95,7 +95,7 @@ class Profiler implements ProfilerInterface, \IteratorAggregate, \Countable
      * @since   1.0
      * @throws  \InvalidArgumentException
      */
-    public function __construct($name, ProfilerRendererInterface $renderer = null, array $points = [], $memoryRealUsage = false)
+    public function __construct($name, ?ProfilerRendererInterface $renderer = null, array $points = [], $memoryRealUsage = false)
     {
         $this->name     = $name;
         $this->renderer = $renderer ?: new DefaultRenderer();


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no