### PR TITLE
Remove phpstan.neon from release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,6 @@ Tests/ export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
 ruleset.xml export-ignore


### PR DESCRIPTION
### Summary of Changes
This removes the phpstan.neon files from the final release package
